### PR TITLE
fix: update environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_SUBSCRIBER_ID=on-boarding-subscriber-id-123
 NEXT_PUBLIC_NOVU_APP_ID=xxxxxx
 NEXT_PUBLIC_NOVU_API_KEY=xxxxxxx
+NEXT_WORKFLOW_TRIGGER_ID=xxxxxxx
 NEXT_BACKEND_API_URL=https://dev.api.novu.co


### PR DESCRIPTION
This PR updates to the `.env.example`, adding the missing `NEXT_WORKFLOW_TRIGGER_ID` environment variable.